### PR TITLE
fix condition for supplements

### DIFF
--- a/commandes.js
+++ b/commandes.js
@@ -19,6 +19,10 @@ export class Commande {
         this.supplements = supplements;
         this.drink = drink;
         this.total = this.defineFinalPrice() + " €";
+        this.checkFieldsValidity()
+    }
+
+    checkFieldsValidity() {
         this.checkNumberMeatsOk();
         this.checkNumberSaucesOk();
         this.neverRepeatChoiceSupplements();
@@ -94,7 +98,7 @@ export class Commande {
     defineFinalPrice() {
 
         let result = sizesAndPrices[this.size];
-        result += (this.supplements != ['None']) ? this.supplements.length : 0;
+        result += (!this.supplements.includes('None')) ? this.supplements.length : 0;
         if (this.drink != 'None') {
             result += (this.drink == 'Vittel') ? 0.5 : 1;
         }


### PR DESCRIPTION
Utiliser la methode `includes()` du prototype javascript `Array` qui permet de savoir si un array contient un objet. 
Ajouter `!` pour inverser la condition, car on veut que l'array ne contienne pas 'None', et non pas qu'il le contienne.﻿
